### PR TITLE
Add support for video memes in attachments

### DIFF
--- a/src/main/kotlin/cloud/osasoft/discordMemeScores/commands/MemeCmd.kt
+++ b/src/main/kotlin/cloud/osasoft/discordMemeScores/commands/MemeCmd.kt
@@ -26,13 +26,7 @@ fun memeListener() = commands("Memes") {
     ): List<Message> = event.channel.getMessagesAfter(messageId = Snowflake(cutOffDate.toKotlinInstant()))
         .filter { it.author?.id == event.author.id }
         .filter { message ->
-            val embedType = message.data.embeds.firstOrNull()?.type?.value.toString()
-            message.isImagePost() ||
-            embedType.endsWith(".Gifv") ||
-            embedType.endsWith(".Image") ||
-            embedType.endsWith(".Video")
-            // article in case you want to count with embeds that contain text and thumbnail e.g.: 9gag links
-            // || embedType.endsWith(".Article")
+            message.isImagePost() || isEmbedMeme(message) || isVideoMeme(message)
         }
         .toList()
 

--- a/src/main/kotlin/cloud/osasoft/discordMemeScores/commands/MemeFilters.kt
+++ b/src/main/kotlin/cloud/osasoft/discordMemeScores/commands/MemeFilters.kt
@@ -1,0 +1,13 @@
+package cloud.osasoft.discordMemeScores.commands
+
+import dev.kord.core.entity.Message
+
+fun isEmbedMeme(message: Message): Boolean {
+    val embedType = message.data.embeds.firstOrNull()?.type?.value.toString()
+    return embedType.endsWith(".Gifv") || embedType.endsWith(".Image") || embedType.endsWith(".Video")
+}
+
+fun isVideoMeme(message: Message): Boolean {
+    val messageAttachment = message.data.attachments.firstOrNull()?.contentType?.value.toString()
+    return messageAttachment.startsWith("video")
+}


### PR DESCRIPTION
I've added filter for recognizing videos in message attachments and moved filters to another file.